### PR TITLE
collect additional agent stats

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.12.rc.3)
+    coverband-service-client (0.0.12.rc.4)
       coverband (~> 4.2.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.12.rc)
+    coverband-service-client (0.0.12.rc.1)
       coverband (~> 4.2.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.12.rc.1)
+    coverband-service-client (0.0.12.rc.2)
       coverband (~> 4.2.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.12.rc.4)
+    coverband-service-client (0.0.12)
       coverband (~> 4.2.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.12)
+    coverband-service-client (0.0.12.rc)
       coverband (~> 4.2.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.11)
+    coverband-service-client (0.0.12)
       coverband (~> 4.2.4)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    coverband-service-client (0.0.12.rc.2)
+    coverband-service-client (0.0.12.rc.3)
       coverband (~> 4.2.4)
 
 GEM

--- a/bin/stats
+++ b/bin/stats
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+
+ENV['COVERBAND_ENABLE_DEV_MODE'] = 'true'
+ENV['COVERBAND_ENABLE_TEST_MODE'] = 'true'
+ENV['PROCESS_TYPE'] = 'debug'
+ENV['COVERBAND_REPORT_PERIOD'] = '30'
+ENV['COVERBAND_API_KEY'] ||= 'set this'
+ENV['COVERBAND_STATS_KEY'] ||='set this'
+
+require "pry-byebug";
+require "dogapi";
+require "net/http/persistent";
+# require "httplog";
+require 'benchmark'
+
+require_relative "../lib/coverband-service-client"
+
+# HttpLog.configure do |config|
+#   config.url_SAFElist_pattern = /coverband/
+# end
+
+data = {
+  'app/helpers/posts_helper.rb' => [1, nil]
+}
+
+collector = Coverband::Collectors::Coverage.instance
+store = Coverband.configuration.store
+
+# What is the recommended timeout against the target, from the lib
+# puts store.recommended_timeout
+
+Benchmark.bmbm do |x|
+  x.report("connection") do
+    30.times do
+      store.save_report(data)
+    end
+  end
+end
+
+puts "done"

--- a/coverband-service-client.gemspec
+++ b/coverband-service-client.gemspec
@@ -28,6 +28,14 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
+
+  # For benchmarking stats
+  # spec.add_development_dependency "pry-byebug"
+  # spec.add_development_dependency "dogapi"
+  # spec.add_development_dependency "httplog"
+  # # to benchmark persistent connections
+  # spec.add_development_dependency "net-http-persistent"
+
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_runtime_dependency "coverband", "~> 4.2.4"
 end

--- a/lib/coverband-service-client.rb
+++ b/lib/coverband-service-client.rb
@@ -56,6 +56,7 @@ module Coverband
           return unless defined?(Dogapi::Client)
 
           @stats = Dogapi::Client.new(ENV['COVERBAND_STATS_KEY'])
+          @app_name = defined?(Rails) ? Rails.application.class.module_parent.to_s : "unknown"
         end
 
         def report_timing(timing)

--- a/lib/coverband-service-client.rb
+++ b/lib/coverband-service-client.rb
@@ -46,6 +46,7 @@ module Coverband
           @coverband_url = coverband_url
           @process_type = opts.fetch(:process_type) { $PROGRAM_NAME&.split('/')&.last || COVERBAND_PROCESS_TYPE }
           @hostname = opts.fetch(:hostname) { ENV["DYNO"] || Socket.gethostname.force_encoding('utf-8').encode }
+          @hostname = @hostname.gsub("'",'').gsub("’",'')
           @runtime_env = opts.fetch(:runtime_env) { COVERBAND_ENV }
           initialize_stats
         end
@@ -64,8 +65,8 @@ module Coverband
             'coverband.save.time',
             timing,
             host: hostname,
-            env: runtime_env,
-            client: "coverband_#{self.class.name.split("::").last}")
+            device: "coverband_#{self.class.name.split("::").last}",
+            options: {tags: [runtime_env]})
         end
 
         def logger

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.12.rc.2'
+      VERSION = '0.0.12.rc.3'
     end
   end
 end

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.12.rc'
+      VERSION = '0.0.12.rc.1'
     end
   end
 end

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.12.rc.1'
+      VERSION = '0.0.12.rc.2'
     end
   end
 end

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.11'
+      VERSION = '0.0.12'
     end
   end
 end

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.12.rc.4'
+      VERSION = '0.0.12'
     end
   end
 end

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.12.rc.3'
+      VERSION = '0.0.12.rc.4'
     end
   end
 end

--- a/lib/coverband/service/client/version.rb
+++ b/lib/coverband/service/client/version.rb
@@ -1,7 +1,7 @@
 module Coverband
   module Service
     module Client
-      VERSION = '0.0.12'
+      VERSION = '0.0.12.rc'
     end
   end
 end


### PR DESCRIPTION
This avoids hitting our server when there is no API key.

We also collect some additional stats that could be used for filtering.